### PR TITLE
Change from querystring.parse to querystring.decode

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export * as querystring from "https://esm.sh/query-string";
+export * as querystring from "https://esm.sh/querystring";
 export { humanStr as parseTimestamp } from "https://raw.githubusercontent.com/fent/node-m3u8stream/master/src/parse-time.ts";
 export * as sax from "https://deno.land/x/sax_ts@v1.2.10/src/sax.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export * as querystring from "https://esm.sh/querystring";
+export * as querystring from "https://esm.sh/query-string";
 export { humanStr as parseTimestamp } from "https://raw.githubusercontent.com/fent/node-m3u8stream/master/src/parse-time.ts";
 export * as sax from "https://deno.land/x/sax_ts@v1.2.10/src/sax.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export * as querystring from "https://esm.sh/querystring";
+export * as querystring from "https://esm.sh/querystring@0.2.1";
 export { humanStr as parseTimestamp } from "https://raw.githubusercontent.com/fent/node-m3u8stream/master/src/parse-time.ts";
 export * as sax from "https://deno.land/x/sax_ts@v1.2.10/src/sax.ts";

--- a/src/info.ts
+++ b/src/info.ts
@@ -416,7 +416,7 @@ const getVideoInfoPage = async (id: string, options: GetInfoOptions) => {
   url.searchParams.set("cver", `7${cver.substr(1)}`);
   url.searchParams.set("html5", "1");
   let body = await request(url.toString(), options).then((e) => e.text());
-  let info = querystring.parse(body);
+  let info = querystring.decode(body);
   info.player_response = findPlayerResponse("get_video_info", info);
   return info;
 };

--- a/src/sig.ts
+++ b/src/sig.ts
@@ -171,7 +171,7 @@ export const decipherFormats = async (
   formats.forEach((format) => {
     let cipher = format.signatureCipher || format.cipher;
     if (cipher) {
-      Object.assign(format, querystring.parse(cipher));
+      Object.assign(format, querystring.decode(cipher));
       delete format.signatureCipher;
       delete format.cipher;
     }


### PR DESCRIPTION
The `parse` function of `querystring` is undefined, `decode` does work so I changed it to that
Another solution is to lock to an older version that does have parse?